### PR TITLE
Added changes to accept all characters as a preprocessor directive

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -6,7 +6,7 @@
 //const
 var
     RE_VARPAIR = /^\s*([^\s=]+)\s*=?(.*)/,
-    RE_VARNAME = /^\s*([$_A-Z][_0-9A-Z]+)\s*$/
+    RE_VARNAME = /^\s*([$_A-Za-z][_0-9A-Za-z]+)\s*$/
 
 // Options globals
 var _filters = Options.filters = {


### PR DESCRIPTION
The current configuration doesn't allow if the symbol is comprised of only lowercase characters hence the change